### PR TITLE
Fix issue with variable name, when setting Project or Product tokens

### DIFF
--- a/bin/ws_post.js
+++ b/bin/ws_post.js
@@ -130,9 +130,9 @@ WsPost.postNpmUpdateJson = function(report,confJson,postCallback){
 
 	  //if both Project-Token and ProductToken send the Project-Token
 	  if(reqOpt.projectToken){
-		myPost.projectToken = reqOpt.projectToken;
+		myRequest.myPost.projectToken = reqOpt.projectToken;
 	  }else if(reqOpt.productToken){
-		myPost.productToken = reqOpt.productToken;
+		myRequest.myPost.productToken = reqOpt.productToken;
 	  }
 
 


### PR DESCRIPTION
You are using the wrong variable name to set the project's or the product tokens when using either.