### PR TITLE
fix(dependencies): add prod dependencies only when flag devDep is set to false

### DIFF
--- a/bin/whitesource.js
+++ b/bin/whitesource.js
@@ -199,7 +199,7 @@ cli.main(function (args, options){
 			cli.fatal(missingPackgeJsonMsg);
 		}
 
-		var cmd = (confJson.devDep === "true") ? 'npm shrinkwrap --dev' : 'npm shrinkwrap';
+		var cmd = (confJson.devDep === "true") ? 'npm shrinkwrap --dev' : 'npm shrinkwrap --only=prod';
 		exec(cmd,function(error, stdout, stderr){
 		    if (error != 0){
 		    	cli.ok('exec error: ', error);


### PR DESCRIPTION
 npm@4 and up now includes dev dependencies to the shrinkwrap by default 

With '--only=prod' only the prod dependencies are added.

https://github.com/npm/npm/issues/14250