### PR TITLE
Add the option to specify the api key from an env variable

### DIFF
--- a/bin/whitesource.js
+++ b/bin/whitesource.js
@@ -207,6 +207,9 @@ cli.main(function (args, options){
 		confPath = args[0];
 	}
 	var confJson = WsHelper.initConf(confPath);
+	if (!confJson.apiKey && process.env.WHITESOURCE_API_KEY) {
+		confJson.apiKey = process.env.WHITESOURCE_API_KEY;
+	}
 	if (!confJson) abortUpdate();
 	isFailOnError = confJson.hasOwnProperty(failOnErrorField) && (confJson.failOnError === true || confJson.failOnError === "true");
 	isForceUpdate = confJson.hasOwnProperty(forceUpdateField) && (confJson.forceUpdate === true || confJson.forceUpdate === "true");


### PR DESCRIPTION
I don't want to commit my API key to source control. It's common in continuous integration systems to inject secrets like the api key via an environment variable.

Adds support for a `WHITESOURCE_API_KEY` environment variable which is used if the api key is not present in the configuration file.